### PR TITLE
Fixed an index error bug in the picker.

### DIFF
--- a/atoman/gui/pipelineForm.py
+++ b/atoman/gui/pipelineForm.py
@@ -908,13 +908,13 @@ class PipelineForm(QtGui.QWidget):
                 
                 minSepScalars = {}
                 for scalarType, scalarArray in six.iteritems(scalarsDict):
-                    minSepScalars[scalarType] = scalarArray[tmp_index]
+                    minSepScalars[scalarType] = scalarArray[int(tmp_index)]
                 for scalarType, scalarArray in six.iteritems(latticeScalarsDict):
-                    minSepScalars[scalarType] = scalarArray[tmp_index]
+                    minSepScalars[scalarType] = scalarArray[int(tmp_index)]
                 
                 minSepVectors = {}
                 for vectorType, vectorArray in six.iteritems(vectorsDict):
-                    minSepVectors[vectorType] = vectorArray[tmp_index]
+                    minSepVectors[vectorType] = vectorArray[int(tmp_index)]
         
         logger.debug("Closest object to pick: %f (threshold: %f)", minSep, 0.1)
         


### PR DESCRIPTION
Hi Chris,

After updating my python I saw this error from the picker when I had filters applied.

Traceback (most recent call last):
  File "atoman/gui/rendererSubWindow.py", line 574, in endPickEvent
  File "atoman/gui/pipelineForm.py", line 911, in pickObject
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices

Type casting the tmp_index variable fixes the problem.

Regards,

Kenny